### PR TITLE
feat(Post):판매완료 표시,필터링 구현

### DIFF
--- a/src/components/products/product.jsx
+++ b/src/components/products/product.jsx
@@ -1,3 +1,4 @@
+// src/components/products/product.jsx
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { FaImage } from "react-icons/fa";
@@ -14,6 +15,9 @@ const Product = ({ post, onClick, variant = "default" }) => {
   const navigate = useNavigate();
   const [signedUrl, setSignedUrl] = useState("");
   const [loading, setLoading] = useState(false);
+
+  // 🔹 판매 상태 (백엔드 enum: ON_SALE, SOLD)
+  const isSold = post?.status === "SOLD";
 
   useEffect(() => {
     let cancelled = false;
@@ -55,7 +59,7 @@ const Product = ({ post, onClick, variant = "default" }) => {
 
   const variants = {
     compact: {
-      wrapper: "w-[130px] h-[230px] ",
+      wrapper: "w-[130px] h-[230px]",
       imageHeight: "h-[120px]",
       titleText: "font-semibold text-[11px]",
       priceText: "text-[10px] font-semibold",
@@ -63,7 +67,7 @@ const Product = ({ post, onClick, variant = "default" }) => {
       iconSize: 50,
     },
     default: {
-      wrapper: "w-[190px] h-[320px] ",
+      wrapper: "w-[190px] h-[320px]",
       imageHeight: "h-[200px]",
       titleText: "font-semibold text-[15px]",
       priceText: "text-[14px] font-semibold",
@@ -75,7 +79,7 @@ const Product = ({ post, onClick, variant = "default" }) => {
   const currentStyle = variants[variant] || variants.default;
 
   return (
-    <div className={`${currentStyle.wrapper}`}>
+    <div className={currentStyle.wrapper}>
       <div
         role="button"
         tabIndex={0}
@@ -87,8 +91,9 @@ const Product = ({ post, onClick, variant = "default" }) => {
                    hover:shadow-md hover:-translate-y-[2px] transition-transform text-left
                    focus:outline-none focus:ring-2 focus:ring-blue-300"
       >
+        {/* 🔹 이미지 영역 */}
         <div
-          className={`m-3 ${currentStyle.imageHeight} bg-gray-200 rounded-[10px] overflow-hidden flex items-center justify-center`}
+          className={`relative m-3 ${currentStyle.imageHeight} bg-gray-200 rounded-[10px] overflow-hidden flex items-center justify-center`}
         >
           {signedUrl ? (
             <img
@@ -100,12 +105,25 @@ const Product = ({ post, onClick, variant = "default" }) => {
             />
           ) : (
             <FaImage
-              size={`${currentStyle.iconSize}`}
+              size={currentStyle.iconSize}
               className="text-rebay-gray-300"
             />
           )}
+
+          {/* 🔹 판매완료 오버레이 (SOLD일 때만) */}
+          {isSold && (
+            <div className="absolute inset-0 flex items-center justify-center">
+              {/* 배경 살짝 어둡게 */}
+              <div className="absolute inset-0 bg-black/20" />
+              {/* 동그란 배지 */}
+              <div className="relative flex items-center justify-center w-[86px] h-[86px] rounded-full bg-black/60 text-white text-xs font-semibold">
+                판매완료
+              </div>
+            </div>
+          )}
         </div>
 
+        {/* 🔹 텍스트 영역 */}
         <div className="mx-3 mb-3">
           <div
             className={`${currentStyle.titleText} leading-snug line-clamp-1`}

--- a/src/pages/search.jsx
+++ b/src/pages/search.jsx
@@ -368,7 +368,7 @@ export default function Search() {
                       sort === SORTS.LATEST ? "bg-rebay-blue text-white" : ""
                     }`}
                   >
-                    최신
+                    최신순
                   </button>
                   <button
                     onClick={() => setSort(SORTS.PRICE_ASC)}
@@ -376,7 +376,7 @@ export default function Search() {
                       sort === SORTS.PRICE_ASC ? "bg-rebay-blue text-white" : ""
                     }`}
                   >
-                    가격 오름차순
+                    높은 가격순
                   </button>
                   <button
                     onClick={() => setSort(SORTS.PRICE_DESC)}
@@ -386,7 +386,7 @@ export default function Search() {
                         : ""
                     }`}
                   >
-                    가격 내림차순
+                    낮은 가격순
                   </button>
                   <button
                     onClick={() => setSort(SORTS.TITLE_ASC)}


### PR DESCRIPTION


## 📝작업 내용

- 거래 완료시 Post에 판매완료 표시
- 정렬 Rename
- 초기 화면 판매완료상품 출력 x / 박스 체크시 판매완료 상품 확인 가능


## 결과

1. 판매완료 표시

<img width="896" height="510" alt="image" src="https://github.com/user-attachments/assets/7e4c6533-908a-44d2-ab49-6030e3630da3" />


2. 정렬  Rename

<img width="337" height="40" alt="image" src="https://github.com/user-attachments/assets/592a6ab5-cbde-4c1e-a932-3bf74b788aa2" />

3.  - 초기 화면 판매완료상품 출력 x / 박스 체크시 판매완료 상품 확인 가능

<img width="870" height="559" alt="image" src="https://github.com/user-attachments/assets/1c827b2b-48ae-4eb7-9104-bec0b2038478" />

3-1 . 체크박스 체크시 판매완료 상품 확인가능
<img width="843" height="558" alt="image" src="https://github.com/user-attachments/assets/d1a5e909-395f-4926-9541-a7f074d197aa" />
